### PR TITLE
Update the apt cache before installing the package.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: ensure unattended-upgrades package is installed
   become: yes
   become_method: sudo
-  apt: name=unattended-upgrades state=present
+  apt: name=unattended-upgrades state=present update_cache=true cache_valid_time=3600
 
 - name: setup unattended-upgrades configuration file
   become: yes


### PR DESCRIPTION
If the apt cache is too old then this role can fail to install.

I've changed the apt module call to update the cache if it's older than an hour.

Example output with a (very) old cache:
```
fatal: [host]: FAILED! => {"cache_update_time": 1494962379, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'unattended-upgrades'' failed: E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/u/unattended-upgrades/unattended-upgrades_0.90ubuntu0.5_all.deb  404  Not Found\n\nE: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?\n", "rc": 100, "stderr": "E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/u/unattended-upgrades/unattended-upgrades_0.90ubuntu0.5_all.deb  404  Not Found\n\nE: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?\n", "stderr_lines": ["E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/u/unattended-upgrades/unattended-upgrades_0.90ubuntu0.5_all.deb  404  Not Found", "", "E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following additional packages will be installed:\n  python3-apt\nSuggested packages:\n  python3-apt-dbg python-apt-doc\nThe following NEW packages will be installed:\n  python3-apt unattended-upgrades\n0 upgraded, 2 newly installed, 0 to remove and 33 not upgraded.\nNeed to get 170 kB of archives.\nAfter this operation, 940 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 python3-apt amd64 1.1.0~beta1build1 [137 kB]\nErr:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 unattended-upgrades all 0.90ubuntu0.5\n  404  Not Found\nFetched 137 kB in 0s (255 kB/s)\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  python3-apt", "Suggested packages:", "  python3-apt-dbg python-apt-doc", "The following NEW packages will be installed:", "  python3-apt unattended-upgrades", "0 upgraded, 2 newly installed, 0 to remove and 33 not upgraded.", "Need to get 170 kB of archives.", "After this operation, 940 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu xenial/main amd64 python3-apt amd64 1.1.0~beta1build1 [137 kB]", "Err:2 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 unattended-upgrades all 0.90ubuntu0.5", "  404  Not Found", "Fetched 137 kB in 0s (255 kB/s)"]}
```